### PR TITLE
More robust .version logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ number when deploying your service, and return a version number to
 stdout.
 
 ## Three supported scenarios
+As described below, `version.sh` output is contingent on:
+- git branch of the project (`master` vs. non-`master`)
+- presence of a `.version` file
 
-### .version (on master branch)
+### .version file on master branch
 If you track versions manually, either using SemVer or some other
 scheme, you can put it into a `.version` file in the root directory of
 your project. The contents of the `.version` file are returned with
@@ -14,7 +17,7 @@ a `v` prefix. For example... contents of version file:
 1.0.0
 ```
 
-version.sh output:
+`version.sh` output:
 
 ```
 v1.0.0
@@ -24,16 +27,16 @@ Note: You could auto-generate a `.version` file automatically (eg. via
 Travis-CI) based on that same information tracked elsewhere, such as
 `package.json`.
 
-### YYYY-MM-DD.SHA (on master branch)
+### YYYY-MM-DD.SHA on master branch
 If you do not track versions manually (i.e. a `.version` file does not
 exist in your project), a version will be created using the current
 date followed by the git SHA of the HEAD, e.g. `2019-10-2.b3bf3d9`
 
-### branch/sha (on non-master branch)
+### branch/sha on non-master branch
 If you are not on master, the version will indicate the deployed
 branch followed by the SHA of that branch,
 e.g. `a-test-branch/53574e8`, irrespective of whether you have a
-tracked version for `master`
+tracked version for `master`.
 
 ## Example usage
 This is a handy one-liner that can be used in a build script:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,42 @@
 # version.sh
-This shell script will inspect your project to determine a version number when deploying your service, and return a version number to stdout It handles three cases:
+This shell script will inspect your project to determine a version
+number when deploying your service, and return a version number to
+stdout.
 
-## .version
-If you track versions manually, either using SemVer or some other scheme, you can put it into a `.version` file (you could even generate one automatically in your travis build based on that same information tracked elsewhere, such as a `package.json`.). The entire contents of the `.version` file are returned verbatim.
+## Three supported scenarios
 
-## YYYY-MM-DD.SHA
-If you do not track versions manually (i.e. a `.version` file does not exist in your project), a version will be created using the current date followed by the git SHA of the HEAD, e.g. `2019-10-2.b3bf3d9`
+### .version (on master branch)
+If you track versions manually, either using SemVer or some other
+scheme, you can put it into a `.version` file in the root directory of
+your project. The contents of the `.version` file are returned with
+a `v` prefix. For example... contents of version file:
+```
+1.0.0
+```
 
-## branch/sha
-If you are not on master, the version will indicate the deployed branch followed by the SHA of that branch, e.g. `a-test-branch/53574e8`, irrespective of whether you have a tracked version for `master`
+version.sh output:
+
+```
+v1.0.0
+```
+
+Note: You could auto-generate a `.version` file automatically (eg. via
+Travis-CI) based on that same information tracked elsewhere, such as
+`package.json`.
+
+### YYYY-MM-DD.SHA (on master branch)
+If you do not track versions manually (i.e. a `.version` file does not
+exist in your project), a version will be created using the current
+date followed by the git SHA of the HEAD, e.g. `2019-10-2.b3bf3d9`
+
+### branch/sha (on non-master branch)
+If you are not on master, the version will indicate the deployed
+branch followed by the SHA of that branch,
+e.g. `a-test-branch/53574e8`, irrespective of whether you have a
+tracked version for `master`
+
+## Example usage
+This is a handy one-liner that can be used in a build script:
+``` shell
+wget -O - https://github.com/SenteraLLC/version.sh/raw/master/version.sh | bash
+```

--- a/version.sh
+++ b/version.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
+BASEDIR=$(git rev-parse --show-toplevel)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SHA=$(git rev-parse --short HEAD)
 DATE=$(date --rfc-3339=date)
 
 if [[ $BRANCH = "master" ]]; then
   if [[ -e ".version" ]]; then
-    echo $(cat .version)
-  else 
+    echo "v$(cat ${BASEDIR}/.version)"
+  else
     echo "${DATE}.${SHA}"
   fi
 else


### PR DESCRIPTION
- Reference `.version` file relative to git root rather than the current working directory for robustness
- Add `v` prefix when using contents of `.version` file. This matches the behavior of our two previous version implementations.

I successfully tested these changes on feature branch `version-file-test`.