### PR TITLE
Handle "main" Branch Same as "master"

### DIFF
--- a/env-tags.sh
+++ b/env-tags.sh
@@ -2,7 +2,7 @@
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ $BRANCH = "master" ]]; then
+if [[ $BRANCH = "master" ]] || [[ $BRANCH = "main" ]]; then
   echo "prod dev"
 elif [[ $BRANCH = staging.* ]]; then
   echo "staging staging2"

--- a/version.sh
+++ b/version.sh
@@ -5,7 +5,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SHA=$(git rev-parse --short HEAD)
 DATE=$(date --rfc-3339=date)
 
-if [[ $BRANCH = "master" ]]; then
+if [[ $BRANCH = "master" ]] || [[ $BRANCH = "main" ]]; then
   if [[ -e ".version" ]]; then
     echo "v$(cat ${BASEDIR}/.version)"
   else


### PR DESCRIPTION
# What?
This PR updates the version logic to handle "main" branches the same as "master".

## Why?
"main" is the new default name for the central remote branch.

## QA Strategy
- [ ] Verify this ouputs the correct tags on a "main" branch.
