### PR TITLE
Updates based on repo name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
-# version.sh
+This repository contains shell scripts that assist in the process of building Sentera's various services that run on AWS.
+
+## env-tags.sh
+This shell script is used when building a Docker image to determine the environments for which the image should be tagged, based upon the branch (`main/master` or `staging*`) being built.
+
+For example, when building on the `main` or `master` branch, the image should be tagged for the `prod` and `dev` environments.
+
+### Example usage
+This is a handy one-liner that can be used in a build script:
+``` shell
+env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/master/env-tags.sh | bash)
+```
+
+## push-to-ecr.sh
+This shell script pushes a built Docker image and tags that reference this image to AWS ECR.
+
+For example, when building on the `main` or `master` branch, the resulting tags pushed to ECR would look like the following: `2021-09-09.2a638c4`, `dev`, `prod`.
+
+### Example usage
+This is a handy one-liner that can be used in a build script:
+``` shell
+wget -O - https://github.com/SenteraLLC/version.sh/raw/master/push-to-ecr.sh | bash
+```
+
+## version.sh
 This shell script will inspect your project to determine a version
 number when deploying your service, and return a version number to
 stdout.
 
-## Three supported scenarios
+### Three supported scenarios
 As described below, `version.sh` output is contingent on:
 - git branch of the project (`master` vs. non-`master`)
 - presence of a `.version` file
 
-### .version file on master branch
+#### .version file on master branch
 If you track versions manually, either using SemVer or some other
 scheme, you can put it into a `.version` file in the root directory of
 your project. The contents of the `.version` file are returned with
@@ -27,18 +51,18 @@ Note: You could auto-generate a `.version` file automatically (eg. via
 Travis-CI) based on that same information tracked elsewhere, such as
 `package.json`.
 
-### YYYY-MM-DD.SHA on master branch
+#### YYYY-MM-DD.SHA on master branch
 If you do not track versions manually (i.e. a `.version` file does not
 exist in your project), a version will be created using the current
 date followed by the git SHA of the HEAD, e.g. `2019-10-2.b3bf3d9`
 
-### branch/sha on non-master branch
+#### branch/sha on non-master branch
 If you are not on master, the version will indicate the deployed
 branch followed by the SHA of that branch,
 e.g. `a-test-branch/53574e8`, irrespective of whether you have a
 tracked version for `master`.
 
-## Example usage
+### Example usage
 This is a handy one-liner that can be used in a build script:
 ``` shell
 wget -O - https://github.com/SenteraLLC/version.sh/raw/master/version.sh | bash

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ tracked version for `master`.
 ### Example usage
 This is a handy one-liner that can be used in a build script:
 ``` shell
-wget -O - https://github.com/SenteraLLC/version.sh/raw/master/version.sh | bash
+wget -O - https://github.com/SenteraLLC/build-support/raw/master/version.sh | bash
 ```

--- a/push-to-ecr.sh
+++ b/push-to-ecr.sh
@@ -9,7 +9,7 @@ ECR_IMAGE="${ECR_IMAGE_PREFIX}:${VERSION_TAG}"
 echo "Pushing ${ECR_IMAGE}"
 docker tag $VERSION_TAG $ECR_IMAGE
 docker push $ECR_IMAGE
-env_tags=$(wget -O - https://github.com/SenteraLLC/version.sh/raw/master/env-tags.sh | bash)
+env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/master/env-tags.sh | bash)
 for env_tag in $env_tags; do
   full_tag="${ECR_IMAGE_PREFIX}:${env_tag}"
   echo "Pushing ${full_tag}"


### PR DESCRIPTION
https://sentera.atlassian.net/browse/FA-2600

* Updated README.md to reflect the broader usage of the repo.
* Switched `push-to-ecr.sh` to reference the `env-tags.sh` script via the build-support repo instead of the version.sh repo.

**QA Plan**
- [x] Verify that `wget -O - https://github.com/SenteraLLC/version.sh/raw/master/version.sh` still works to retrieve the `version.sh` script.
- [x] Verify that `wget -O - https://github.com/SenteraLLC/build-support/raw/master/version.sh` works to retrieve the `version.sh` script.
- [x] Verify that the changes made to README.md are accurate.