### PR TITLE
[FA-2713] `v1.1.0`: Simplify `env-tags.sh` Branch -> Environment Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 This repository contains shell scripts that assist in the process of building Sentera's various services that run on AWS.
 
 ## env-tags.sh
-This shell script is used when building a Docker image to determine the environments for which the image should be tagged, based upon the branch (`main/master` or `staging*`) being built.
+This shell script is used when building a Docker image to determine the environments for which the image should be tagged, based upon the branch being built.
 
-For example, when building on the `main` or `master` branch, the image should be tagged for the `prod` and `dev` environments.
+The branch name -> environment name mapping is:
+- `dev.*` branch -> `dev` environment
+- `staging.*` branch -> `staging` environment
+- `staging2.*` branch -> `staging2` environment
+- `main`, `master` branches -> `prod` environment
 
 ### Example usage
 This is a handy one-liner that can be used in a build script:
@@ -14,7 +18,7 @@ env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/master/env-
 ## push-to-ecr.sh
 This shell script pushes a built Docker image and tags that reference this image to AWS ECR.
 
-For example, when building on the `main` or `master` branch, the resulting tags pushed to ECR would look like the following: `2021-09-09.2a638c4`, `dev`, `prod`.
+For example, when building on the `main` or `master` branch, the resulting tags pushed to ECR would look like the following: `2021-09-09.2a638c4`, `prod`.
 
 ### Example usage
 This is a handy one-liner that can be used in a build script:

--- a/env-tags.sh
+++ b/env-tags.sh
@@ -2,8 +2,12 @@
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [[ $BRANCH = "master" ]] || [[ $BRANCH = "main" ]]; then
-  echo "prod dev"
+if [[ $BRANCH = dev.* ]]; then
+  echo "dev"
 elif [[ $BRANCH = staging.* ]]; then
-  echo "staging staging2"
+  echo "staging"
+elif [[ $BRANCH = staging2.* ]]; then
+  echo "staging2"
+elif [[ $BRANCH = "master" ]] || [[ $BRANCH = "main" ]]; then
+  echo "prod"
 fi

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+## Why?
+## What?
+### Screenshot(s)
+### JIRA Link
+## Code Review Strategy
+## QA Strategy
+- [ ] Merge latest main
+- [ ] Regression test
+- [ ] Test new feature

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,5 @@
+**REMINDER:** This is a public repository.
+
 ## Why?
 ## What?
 ### Screenshot(s)

--- a/push-to-ecr.sh
+++ b/push-to-ecr.sh
@@ -9,7 +9,7 @@ ECR_IMAGE="${ECR_IMAGE_PREFIX}:${VERSION_TAG}"
 echo "Pushing ${ECR_IMAGE}"
 docker tag $VERSION_TAG $ECR_IMAGE
 docker push $ECR_IMAGE
-env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/master/env-tags.sh | bash)
+env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/one-to-one-branch-to-environment/env-tags.sh | bash)
 for env_tag in $env_tags; do
   full_tag="${ECR_IMAGE_PREFIX}:${env_tag}"
   echo "Pushing ${full_tag}"

--- a/push-to-ecr.sh
+++ b/push-to-ecr.sh
@@ -9,7 +9,7 @@ ECR_IMAGE="${ECR_IMAGE_PREFIX}:${VERSION_TAG}"
 echo "Pushing ${ECR_IMAGE}"
 docker tag $VERSION_TAG $ECR_IMAGE
 docker push $ECR_IMAGE
-env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/one-to-one-branch-to-environment/env-tags.sh | bash)
+env_tags=$(wget -O - https://github.com/SenteraLLC/build-support/raw/master/env-tags.sh | bash)
 for env_tag in $env_tags; do
   full_tag="${ECR_IMAGE_PREFIX}:${env_tag}"
   echo "Pushing ${full_tag}"


### PR DESCRIPTION
**REMINDER:** This is a public repository.

## What / Why
This PR updates the `env-tags.sh` branch name -> environment mapping to allow developers to deploy to each of our environments explicitly.

We've previously retro'd about how we'd like our CI/CD build process to map branch names more clearly to environments. This mapping simplifies the deploy logic, and also makes environments like `dev` more accessible.

New mapping:
- `dev.*` branch -> `dev` environment
- `staging.*` branch -> `staging` environment
- `staging2.*` branch -> `staging2` environment
- `main`, `master` branches -> `prod` environment

### Screenshot(s)
![image](https://user-images.githubusercontent.com/7377524/137370359-baba5a02-320a-4872-94df-1dd19045460c.png)

### JIRA Link
https://sentera.atlassian.net/browse/FA-2713

## Code Review Strategy


## QA Strategy
- [x] Using an active feature branch in another repo, temporarily update the target `env-tags.sh` to this branch copy and validate deploys to the non-prod environments work properly:
  - [x] `dev.2021.10.14` -> `dev`
  - [x] `staging.2021.10.14` -> `staging`
  - [x] `staging2.2021.10.14` -> `staging2`
- [x] To test `prod`, manually edit the `env-tags.sh` script (diff shown below) to take the branch name via environment variable, and test locally to validate that prod environments work properly:
  - [x] `master` -> `prod`
  - [x] `main` -> `prod`
```
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BRANCH="${BRANCH}"
```